### PR TITLE
Remove outdated link http://dci-in-ruby.info/

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,3 @@ The application is a Rails project. There are a few reasons for it:
 ## Developers
 
 The application has been developed by Victor Savkin and Rinaldi Fonseca.
-
-## Read More
-
-[Read more about DCI and the project.](http://dci-in-ruby.info)
-


### PR DESCRIPTION
As of today, http://dci-in-ruby.info/ redirect to a random phishing site 😭